### PR TITLE
Define WebSocket Re-use

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,9 +127,9 @@
 
   <section id="terminology">
     <h2>Terminology</h2>
-    <p>Fundamental WoT terminology such as Thing or Web Thing, Consumer or WoT
-      Consumer, WoT Thing Description or Thing Description, Interaction Model,
-      Interaction Affordance, Property, Action and Event are defined in
+    <p>Fundamental WoT terminology such as <dfn>Thing</dfn> or <dfn>Web Thing</dfn>, <dfn>Consumer</dfn> or <dfn>WoT
+        Consumer</dfn>, WoT Thing Description or <dfn>Thing Description</dfn>, Interaction Model,
+      <dfn>Interaction Affordance</dfn>, Property, Action and Event are defined in
       the
       <a href="https://www.w3.org/TR/wot-architecture/#terminology">Terminology</a>
       section of the WoT Architecture specification [[wot-architecture11]].
@@ -140,16 +140,16 @@
     <h2>WebSocket Connection</h2>
     <section id="protocol-handshake">
       <h3>Protocol Handshake</h3>
-      <p>In order to communicate with a <a href="https://www.w3.org/TR/wot-architecture11/#dfn-web-thing">Web Thing</a>,
-        a WoT <a href="https://www.w3.org/TR/wot-architecture11/#dfn-consumer">Consumer</a> [[wot-architecture11]] MUST
-        locate one or more WebSocket [[WEBSOCKETS-PROTOCOL]] endpoints provided by the Thing for a given set of <a
-          href="https://www.w3.org/TR/wot-thing-description/#interactionaffordance">interaction affordances</a>
-        [[wot-thing-description11]].</p>
-      <p>The URL of a WebSocket endpoint to be used for a given interaction MUST be obtained from a <a
-          href="https://www.w3.org/TR/wot-architecture11/#dfn-wot-thing-description">Thing Description</a>
+      <p>In order to communicate with a <a>Web Thing</a>,
+        a WoT <a>Consumer</a> [[wot-architecture11]] MUST
+        locate one or more WebSocket [[WEBSOCKETS-PROTOCOL]] endpoints provided by the <a>Thing</a> for a given set of
+        <a>Interaction Affordances</a>
+        [[wot-thing-description11]].
+      </p>
+      <p>The URL of a WebSocket endpoint to be used for a given interaction MUST be obtained from a <a>Thing
+          Description</a>
         [[wot-architecture11]] by locating a <a href="https://www.w3.org/TR/wot-thing-description/#form">Form</a> inside
-        the corresponding <a
-          href="https://www.w3.org/TR/wot-thing-description/#interactionaffordance">InteractionAffordance</a> for which:
+        the corresponding <a>Interaction Affordance</a> for which:
       <ul>
         <li>After being resolved against a <a
             href="https://www.w3.org/TR/wot-thing-description/#td-vocab-base--Thing"><code>base</code></a> URL
@@ -194,8 +194,22 @@
         const socket = new WebSocket('wss://mywebthingserver/things/robot', 'webthingprotocol');
       </pre>
     </section>
-    <section id="protocol-handshake">
+
+    <section id="websocket-reuse">
       <h3>WebSocket Re-use</h3>
+      <p>A single WebSocket [[WEBSOCKETS-PROTOCOL]] connection from a <a>WoT Consumer</a> MAY be shared between multiple
+        <a>Interaction
+          Affordances</a> of a <a>Thing</a>. A single WebSocket connection from a <a>WoT Consumer</a> MAY also be shared
+        between multiple <a>Things</a>.</p>
+      <p>Before opening a new WebSocket connection, a <a>WoT Consumer</a> SHOULD check whether it already has an open
+        connection to the same WebSocket endpoint URL.</p>
+      <p>If an existing connection to the same WebSocket endpoint URL exists, then that connection SHOULD be re-used
+        rather than opening an additional socket.</p>
+      <p>If an existing connection to the same WebSocket endpoint URL exists but is using a different set of credentials
+        for its given <a
+          href="https://www.w3.org/TR/wot-thing-description11/#securityscheme"><code>SecurityScheme</code></a>
+        [[wot-thing-description11]] (e.g. a different Bearer Token), then the <a>WoT Consumer</a> MUST NOT re-use the
+        connection.</p>
     </section>
   </section>
 


### PR DESCRIPTION
These proposed assertions define the circumstances under which a WebSocket connection may be re-used.

This is designed to fulfill requirements 5.2.1.3 and 5.2.1.4 from [section 5.2.1](https://www.w3.org/community/reports/web-thing-protocol/CG-FINAL-web-thing-protocol-requirements-20231101/#websocket-sub-protocol-mechanism) of the Use Cases & Requirements document.

I have also created some local definitions for common terms inside the document which reference the WoT Architecture specification to make it easier to refer to common terms, as is done in other WoT specifications.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/benfrancis/web-thing-protocol/pull/26.html" title="Last updated on Dec 13, 2024, 9:29 PM UTC (bd8bdbe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-thing-protocol/26/59d9aa8...benfrancis:bd8bdbe.html" title="Last updated on Dec 13, 2024, 9:29 PM UTC (bd8bdbe)">Diff</a>