### PR TITLE
Define error conditions for `readallproperties` and `readmultipleproperties` - closes #79 and #80

### DIFF
--- a/index.html
+++ b/index.html
@@ -350,7 +350,8 @@
         </tr>
         <tr>
           <td><a href="#readmultipleproperties"><code>readmultipleproperties</code></a></td>
-          <td><a href="#readmultipleproperties-request">request</a>, <a href="#readmultipleproperties-response">response</a></td>
+          <td><a href="#readmultipleproperties-request">request</a>, <a
+              href="#readmultipleproperties-response">response</a></td>
         </tr>
       </tbody>
     </table>
@@ -761,7 +762,8 @@
       <h3><code>readmultipleproperties</code></h3>
       <section id="readmultipleproperties-request">
         <h4>Request</h4>
-        <p>To request a reading of multiple readable <a>Properties</a> of a <a>Thing</a> at once, a <a>Consumer</a> MUST send a
+        <p>To request a reading of multiple readable <a>Properties</a> of a <a>Thing</a> at once, a <a>Consumer</a> MUST
+          send a
           <a href="#websocket-messages">message</a> to the <a>Thing</a> which contains the following members:
         </p>
         <table class="def">
@@ -873,10 +875,67 @@
           }
         </pre>
       </section>
+      <section id="readmultipleproperties-error-responses">
+        <h4>Error Responses</h4>
+        <p>If a <a>Thing</a> receives a <code>readmultipleproperties</code> request message from a <a>Consumer</a> with
+          a
+          <code>names</code> member which is empty, contains an invalid <a>Property</a> name, or the name of a
+          <a
+            href="https://www.w3.org/TR/wot-thing-description/#td-vocab-writeOnly--DataSchema"><code>writeOnly</code></a>
+          [[wot-thing-description11]] <a>Property</a>, then it MUST send an <a href="#error-response">error response</a>
+          to
+          the <a>Consumer</a> with <code>status</code> set to <code>400</code>.
+        </p>
+        <pre class="example" title="Example readmultipleproperties Bad Request error response message">
+          <code>
+            {
+              "thingID": "https://mythingserver.com/things/mylamp1",
+              "messageID": "72e6f397-8ae9-4882-ac7d-303a953527a5",
+              "messageType": "response",
+              "operation": "readmultipleproperties",
+              "names": ["on", "volume"],
+              "error": {
+                "status": "400",
+                "type": "https://w3c.github.io/web-thing-protocol/errors#400",
+                "title": "Bad Request"
+                "detail": "No property found with the name 'volume'"
+              }
+              "timestamp": "2025-05-22T18:04:33.531Z",
+              "correlationID": "c0503f71-288f-4460-b308-c4cc0009cd89"
+            }
+          </code>
+        </pre>
+        <p>If a <a>Thing</a> receives a <code>readmultipleproperties</code> request message from a <a>Consumer</a> with
+          a
+          <code>names</code> member containing valid <a>Property</a> names but the reading of at least one of the
+          properties
+          unexpectedly fails, then it MUST send an <a href="#error-response">error response</a> to
+          the <a>Consumer</a> with <code>status</code> set to <code>500</code>.
+        </p>
+        <pre class="example" title="Example readmultipleproperties Internal Server Error error response message">
+          <code>
+            {
+              "thingID": "https://mythingserver.com/things/mylamp1",
+              "messageID": "cf0240ca-e21c-49b8-bca4-e27002525ea1",
+              "messageType": "response",
+              "operation": "readmultipleproperties",
+              "names": ["on", "level"],
+              "error": {
+                "status": "500",
+                "type": "https://w3c.github.io/web-thing-protocol/errors#500",
+                "title": "Internal Server Error"
+                "detail": "Reading the 'level' property unexpectedly failed"
+              }
+              "timestamp": "2025-05-22T18:04:33.531Z",
+              "correlationID": "c0503f71-288f-4460-b308-c4cc0009cd89"
+            }
+          </code>
+        </pre>
+      </section>
     </section>
 
-    <section id="error-responses">
-      <h3>Error Responses</h3>
+    <section id="error-response">
+      <h3>Error Response</h3>
       <p>If a <a>Thing</a> experiences an error when attempting to carry out an operation requested by a
         <a>Consumer</a>,
         it MUST send a response message to the <a>Consumer</a> containing the following members:
@@ -917,7 +976,7 @@
             "name": "on",
             "error": {
               "status": "404",
-              "type": "https://w3c.github.io/web-thing-protocol/errors#not-found",
+              "type": "https://w3c.github.io/web-thing-protocol/errors#404",
               "title": "Not Found"
               "detail": "No property found with the name 'on'"
             }

--- a/index.html
+++ b/index.html
@@ -756,6 +756,32 @@
           }
         </pre>
       </section>
+      <section id="readallproperties-error-response">
+        <h4>Error Response</h4>
+        <p>If a <a>Thing</a> receives a <code>readallproperties</code> request message from a <a>Consumer</a>
+          but the reading of at least one of the properties unexpectedly fails, then it MUST send an 
+          <a href="#error-response">error response</a> to the <a>Consumer</a> with <code>status</code> set to 
+          <code>500</code>.
+        </p>
+        <pre class="example" title="Example readallproperties Internal Server Error error response message">
+          <code>
+            {
+              "thingID": "https://mythingserver.com/things/mylamp1",
+              "messageID": "1876e481-5fc2-4b39-93b4-1f434f7b6a47",
+              "messageType": "response",
+              "operation": "readallproperties",
+              "error": {
+                "status": "500",
+                "type": "https://w3c.github.io/web-thing-protocol/errors#500",
+                "title": "Internal Server Error"
+                "detail": "Reading the 'level' property unexpectedly failed"
+              }
+              "timestamp": "2025-05-22T17:15:36.636Z",
+              "correlationID": "c08075a4-d53c-4f51-b251-a6b6922c2b1f"
+            }
+          </code>
+        </pre>
+      </section>
     </section>
 
     <section id="readmultipleproperties">
@@ -875,8 +901,8 @@
           }
         </pre>
       </section>
-      <section id="readmultipleproperties-error-responses">
-        <h4>Error Responses</h4>
+      <section id="readmultipleproperties-error-response">
+        <h4>Error Response</h4>
         <p>If a <a>Thing</a> receives a <code>readmultipleproperties</code> request message from a <a>Consumer</a> with
           a
           <code>names</code> member which is empty, contains an invalid <a>Property</a> name, or the name of a


### PR DESCRIPTION
- Closes #79
- Closes #80

This PR defines specific error conditions for the `readallproperties` and `readmultipleproperties` operations.

It's difficult to know how far to go in defining all possible error conditions but (as suggested in https://github.com/w3c/web-thing-protocol/pull/78#pullrequestreview-2920001715) I think these specific cases warrant a mention, so that it's clear that a partial failure should respond with an error response rather than a success response.

Error conditions for other operations like a `readproperty` operation on a non-existent property name more obviously map onto generic errors in the top level Error Response section like 404, so may not need defining separately for each operation.

This is the first time we've defined an error condition for a specific operation so let me know what you think of the approach.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/benfrancis/web-thing-protocol/pull/81.html" title="Last updated on Jun 12, 2025, 12:12 PM UTC (abeeebe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-thing-protocol/81/ffa63dc...benfrancis:abeeebe.html" title="Last updated on Jun 12, 2025, 12:12 PM UTC (abeeebe)">Diff</a>