### PR TITLE
Update index.html: Fix invalid error type

### DIFF
--- a/index.html
+++ b/index.html
@@ -917,7 +917,7 @@
             "name": "on",
             "error": {
               "status": "404",
-              "type": "https://w3c.github.io/web-thing-protocol/errors#not-found",
+              "type": "https://w3c.github.io/web-thing-protocol/errors#404",
               "title": "Not Found"
               "detail": "No property found with the name 'on'"
             }


### PR DESCRIPTION
The example uses an error type that goes against the defined error types.

Sorry for the unrelated new line at the end of the file. I blame GitHub's web editor.
Feel free to close this PR and reproduce the change in your editor of choice.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jaller94/web-thing-protocol/pull/82.html" title="Last updated on Aug 6, 2025, 3:54 PM UTC (23625da)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-thing-protocol/82/ffa63dc...jaller94:23625da.html" title="Last updated on Aug 6, 2025, 3:54 PM UTC (23625da)">Diff</a>