### PR TITLE
`cancelaction` operation - closes #61

### DIFF
--- a/index.html
+++ b/index.html
@@ -402,6 +402,11 @@
           </td>
         </tr>
         <tr>
+          <td><a href="#cancelaction"><code>cancelaction</code></a></td>
+          <td><a href="#cancelaction-request">request</a>, <a href="#cancelaction-response">response</a>
+          </td>
+        </tr>
+        <tr>
           <td><a href="#subscribeevent"><code>subscribeevent</code></a></td>
           <td><a href="#subscribeevent-request">request</a>,
             <a href="#subscribeevent-response">response</a>,
@@ -2504,6 +2509,123 @@
           the Action then the error member is included in the <code>status</code> member of the response message.
           This helps to differentiate between an error querying the Action status vs. an error executing the Action.
         </p>
+      </section>
+    </section>
+
+    <section id="cancelaction">
+      <h3><code>cancelaction</code></h3>
+      <section id="cancelaction-request">
+        <h4>Request</h4>
+        <p>To cancel an ongoing asynchronous <a>Action</a>, a <a>Consumer</a> MUST send a
+          <a href="#websocket-messages">message</a> to the <a>Thing</a> which contains the following members:
+        </p>
+        <table class="def">
+          <caption>Members of a <code>cancelaction</code> request message</caption>
+          <thead>
+            <tr>
+              <th>Member</th>
+              <th>Type</th>
+              <th>Assignment</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>messageType</code></td>
+              <td>string</td>
+              <td>"request"</td>
+              <td>A string which denotes that this message is a request sent from a Consumer to a Thing.</td>
+            </tr>
+            <tr>
+              <td><code>operation</code></td>
+              <td>string</td>
+              <td>"cancelaction"</td>
+              <td>A string which denotes that this message relates to an <code>cancelaction</code> operation.</td>
+            </tr>
+            <tr>
+              <td><code>actionID</code></td>
+              <td>string</td>
+              <td>Mandatory</td>
+              <td>A unique identifier in UUIDv4 format [[rfc9562]] which identifies the individual action instance being
+                cancelled, as provided in the corresponding <code>invokeaction</code> response.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <pre class="example" title="cancelaction request message">
+        {
+          "thingID": "https://mythingserver.com/things/mylamp1",
+          "messageID": "4672b11e-dc55-465b-a991-0d8de2295fa3",
+          "messageType": "request",
+          "operation": "cancelaction",
+          "actionID": "c1e116a4-7832-4338-a72c-330c871b991a",
+          "correlationID": "03a3cf77-2afc-42a3-bae7-463046dbc736"
+        }
+        </pre>
+        <p>When a <a>Thing</a> receives a message from a <a>Consumer</a> with <code>messageType</code> set to
+          <code>request</code> and <code>operation</code> set to <code>cancelaction</code> it MUST
+          attempt to cancel the <a>Action</a> instance with the <code>actionID</code> provided in the
+          message.
+        </p>
+      </section>
+      <section id="cancelaction-response">
+        <h4>Response</h4>
+        <p>Upon successfully cancelling the an asynchronous <a>Action</a> instance, the <a>Thing</a> MUST send a
+          message to the requesting <a>Consumer</a> containing the following members:
+
+        <table class="def">
+          <caption>Members of a <code>cancelaction</code> response message</caption>
+          <thead>
+            <tr>
+              <th>Member</th>
+              <th>Type</th>
+              <th>Assignment</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>messageType</code></td>
+              <td>string</td>
+              <td>"response"</td>
+              <td>A string which denotes that this message is a response sent from a <a>Thing</a> to a
+                <a>Consumer</a>.
+              </td>
+            </tr>
+            <tr>
+              <td><code>operation</code></td>
+              <td>string</td>
+              <td>"cancelaction"</td>
+              <td>A string which denotes that this message relates to a <code>cancelaction</code> operation.
+              </td>
+            </tr>
+            <tr>
+              <td><code>actionID</code></td>
+              <td>string</td>
+              <td>Mandatory</td>
+              <td>A unique identifier in UUIDv4 format [[rfc9562]] which identifies the individual action instance that
+                was cancelled, as provided in the corresponding <code>invokeaction</code> response.
+              </td>
+            </tr>
+            <tr>
+              <td><code>timestamp</code></td>
+              <td>string</td>
+              <td>Optional</td>
+              <td>A timestamp in date-time format [[RFC3339]] set to the time the action was cancelled.</td>
+            </tr>
+          </tbody>
+        </table>
+        <pre class="example" title="cancelaction response message">
+        {
+          "thingID": "https://mythingserver.com/things/mylamp1",
+          "messageID": "58433430-cb92-4212-b3e8-aff22e8cb977",
+          "messageType": "response",
+          "operation": "cancelaction",
+          "actionID": "c1e116a4-7832-4338-a72c-330c871b991a",
+          "correlationID": "03a3cf77-2afc-42a3-bae7-463046dbc736"
+          "timestamp": "2025-10-03T12:01:53.351Z",
+        }
+        </pre>
       </section>
     </section>
 


### PR DESCRIPTION
Closes #61.

This PR defines request and response message formats for the 'cancelaction' operation, as discussed in #43.

Currently builds on #91 so will need rebasing once that lands.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/benfrancis/web-thing-protocol/pull/93.html" title="Last updated on Oct 15, 2025, 4:31 PM UTC (3779e11)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-thing-protocol/93/aca2a3f...benfrancis:3779e11.html" title="Last updated on Oct 15, 2025, 4:31 PM UTC (3779e11)">Diff</a>