### PR TITLE
`queryallactions` operation - closes #62

### DIFF
--- a/index.html
+++ b/index.html
@@ -401,6 +401,11 @@
           <td><a href="#queryaction-request">request</a>, <a href="#queryaction-response">response</a>
           </td>
         </tr>
+        <tr>
+          <td><a href="#cancelaction"><code>cancelaction</code></a></td>
+          <td><a href="#cancelaction-request">request</a>, <a href="#cancelaction-response">response</a>
+          </td>
+        </tr>
       </tbody>
     </table>
 
@@ -2477,6 +2482,123 @@
           the Action then the error member is included in the <code>status</code> member of the response message.
           This helps to differentiate between an error querying the Action status vs. an error executing the Action.
         </p>
+      </section>
+    </section>
+
+    <section id="cancelaction">
+      <h3><code>cancelaction</code></h3>
+      <section id="cancelaction-request">
+        <h4>Request</h4>
+        <p>To cancel an ongoing asynchronous <a>Action</a>, a <a>Consumer</a> MUST send a
+          <a href="#websocket-messages">message</a> to the <a>Thing</a> which contains the following members:
+        </p>
+        <table class="def">
+          <caption>Members of a <code>cancelaction</code> request message</caption>
+          <thead>
+            <tr>
+              <th>Member</th>
+              <th>Type</th>
+              <th>Assignment</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>messageType</code></td>
+              <td>string</td>
+              <td>"request"</td>
+              <td>A string which denotes that this message is a request sent from a Consumer to a Thing.</td>
+            </tr>
+            <tr>
+              <td><code>operation</code></td>
+              <td>string</td>
+              <td>"cancelaction"</td>
+              <td>A string which denotes that this message relates to an <code>cancelaction</code> operation.</td>
+            </tr>
+            <tr>
+              <td><code>actionID</code></td>
+              <td>string</td>
+              <td>Mandatory</td>
+              <td>A unique identifier in UUIDv4 format [[rfc9562]] which identifies the individual action instance being
+                cancelled, as provided in the corresponding <code>invokeaction</code> response.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <pre class="example" title="cancelaction request message">
+        {
+          "thingID": "https://mythingserver.com/things/mylamp1",
+          "messageID": "4672b11e-dc55-465b-a991-0d8de2295fa3",
+          "messageType": "request",
+          "operation": "cancelaction",
+          "actionID": "c1e116a4-7832-4338-a72c-330c871b991a",
+          "correlationID": "03a3cf77-2afc-42a3-bae7-463046dbc736"
+        }
+        </pre>
+        <p>When a <a>Thing</a> receives a message from a <a>Consumer</a> with <code>messageType</code> set to
+          <code>request</code> and <code>operation</code> set to <code>cancelaction</code> it MUST
+          attempt to cancel the <a>Action</a> instance with the <code>actionID</code> provided in the
+          message.
+        </p>
+      </section>
+      <section id="cancelaction-response">
+        <h4>Response</h4>
+        <p>Upon successfully cancelling the an asynchronous <a>Action</a> instance, the <a>Thing</a> MUST send a
+          message to the requesting <a>Consumer</a> containing the following members:
+
+        <table class="def">
+          <caption>Members of a <code>cancelaction</code> response message</caption>
+          <thead>
+            <tr>
+              <th>Member</th>
+              <th>Type</th>
+              <th>Assignment</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>messageType</code></td>
+              <td>string</td>
+              <td>"response"</td>
+              <td>A string which denotes that this message is a response sent from a <a>Thing</a> to a
+                <a>Consumer</a>.
+              </td>
+            </tr>
+            <tr>
+              <td><code>operation</code></td>
+              <td>string</td>
+              <td>"cancelaction"</td>
+              <td>A string which denotes that this message relates to a <code>cancelaction</code> operation.
+              </td>
+            </tr>
+            <tr>
+              <td><code>actionID</code></td>
+              <td>string</td>
+              <td>Mandatory</td>
+              <td>A unique identifier in UUIDv4 format [[rfc9562]] which identifies the individual action instance that
+                was cancelled, as provided in the corresponding <code>invokeaction</code> response.
+              </td>
+            </tr>
+            <tr>
+              <td><code>timestamp</code></td>
+              <td>string</td>
+              <td>Optional</td>
+              <td>A timestamp in date-time format [[RFC3339]] set to the time the action was cancelled.</td>
+            </tr>
+          </tbody>
+        </table>
+        <pre class="example" title="cancelaction response message">
+        {
+          "thingID": "https://mythingserver.com/things/mylamp1",
+          "messageID": "58433430-cb92-4212-b3e8-aff22e8cb977",
+          "messageType": "response",
+          "operation": "cancelaction",
+          "actionID": "c1e116a4-7832-4338-a72c-330c871b991a",
+          "correlationID": "03a3cf77-2afc-42a3-bae7-463046dbc736"
+          "timestamp": "2025-10-03T12:01:53.351Z",
+        }
+        </pre>
       </section>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -406,6 +406,11 @@
           <td><a href="#cancelaction-request">request</a>, <a href="#cancelaction-response">response</a>
           </td>
         </tr>
+        <tr>
+          <td><a href="#queryallactions"><code>queryallactions</code></a></td>
+          <td><a href="#queryallactions-request">request</a>, <a href="#queryallactions-response">response</a>
+          </td>
+        </tr>
       </tbody>
     </table>
 
@@ -1416,7 +1421,7 @@
               <td><code>operation</code></td>
               <td>string</td>
               <td>"observeproperty"</td>
-              <td>A string which denotes that this message relates to an <code>observeproperty</code> operation.</td>
+              <td>A string which denotes that this message relates to a <code>observeproperty</code> operation.</td>
             </tr>
             <tr>
               <td><code>name</code></td>
@@ -2258,7 +2263,7 @@
           <a href="#websocket-messages">message</a> to the <a>Thing</a> which contains the following members:
         </p>
         <table class="def">
-          <caption>Members of an <code>queryaction</code> request message</caption>
+          <caption>Members of a <code>queryaction</code> request message</caption>
           <thead>
             <tr>
               <th>Member</th>
@@ -2278,7 +2283,7 @@
               <td><code>operation</code></td>
               <td>string</td>
               <td>"queryaction"</td>
-              <td>A string which denotes that this message relates to an <code>queryaction</code> operation.</td>
+              <td>A string which denotes that this message relates to a <code>queryaction</code> operation.</td>
             </tr>
             <tr>
               <td><code>actionID</code></td>
@@ -2312,7 +2317,7 @@
           message to the requesting <a>Consumer</a> containing the following members:
 
         <table class="def">
-          <caption>Members of an <code>queryaction</code> response message</caption>
+          <caption>Members of a <code>queryaction</code> response message</caption>
           <thead>
             <tr>
               <th>Member</th>
@@ -2513,7 +2518,7 @@
               <td><code>operation</code></td>
               <td>string</td>
               <td>"cancelaction"</td>
-              <td>A string which denotes that this message relates to an <code>cancelaction</code> operation.</td>
+              <td>A string which denotes that this message relates to a <code>cancelaction</code> operation.</td>
             </tr>
             <tr>
               <td><code>actionID</code></td>
@@ -2602,6 +2607,147 @@
       </section>
     </section>
 
+    <section id="queryallactions">
+      <h3><code>queryallactions</code></h3>
+      <section id="queryallactions-request">
+        <h4>Request</h4>
+        <p>To query the status of all ongoing asynchronous <a>Actions</a>, a <a>Consumer</a> MUST send a
+          <a href="#websocket-messages">message</a> to the <a>Thing</a> which contains the following members:
+        </p>
+        <table class="def">
+          <caption>Members of a <code>queryallactions</code> request message</caption>
+          <thead>
+            <tr>
+              <th>Member</th>
+              <th>Type</th>
+              <th>Assignment</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>messageType</code></td>
+              <td>string</td>
+              <td>"request"</td>
+              <td>A string which denotes that this message is a request sent from a Consumer to a Thing.</td>
+            </tr>
+            <tr>
+              <td><code>operation</code></td>
+              <td>string</td>
+              <td>"queryallactions"</td>
+              <td>A string which denotes that this message relates to a <code>queryallactions</code> operation.</td>
+            </tr>
+          </tbody>
+        </table>
+        <pre class="example" title="queryallactions request message">
+        {
+          "thingID": "https://mythingserver.com/things/mylamp1",
+          "messageID": "1af62634-4eca-49cb-b448-95110619ee00",
+          "messageType": "request",
+          "operation": "queryallactions",
+          "correlationID": "4c1c0ebc-775f-4b17-8f0f-e25c415f033d"
+        }
+        </pre>
+        <p>When a <a>Thing</a> receives a message from a <a>Consumer</a> with <code>messageType</code> set to
+          <code>request</code> and <code>operation</code> set to <code>queryallactions</code> it MUST
+          attempt to query the status of all ongoing and recently completed <a>Action</a> instances the Consumer
+          has permission to access across all Action affordances of the <a>Thing</a>.
+        </p>
+      </section>
+      <section id="queryallactions-response">
+        <h4>Response</h4>
+        <p>Upon successfully querying the status of all asynchronous <a>Actions</a>, the <a>Thing</a> MUST send a
+          message to the requesting <a>Consumer</a> containing the following members:
+        <table class="def">
+          <caption>Members of a <code>queryallactions</code> response message</caption>
+          <thead>
+            <tr>
+              <th>Member</th>
+              <th>Type</th>
+              <th>Assignment</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>messageType</code></td>
+              <td>string</td>
+              <td>"response"</td>
+              <td>A string which denotes that this message is a response sent from a <a>Thing</a> to a
+                <a>Consumer</a>.
+              </td>
+            </tr>
+            <tr>
+              <td><code>operation</code></td>
+              <td>string</td>
+              <td>"queryallactions"</td>
+              <td>A string which denotes that this message relates to a <code>queryallactions</code> operation.
+              </td>
+            </tr>
+            <tr>
+              <td><code>statuses</code></td>
+              <td>object</td>
+              <td>Mandatory</td>
+              <td>An object, keyed by <a>Action</a> name, with the value of each member being an array of
+                <a href="#action-status-object"><code>ActionStatus</code></a> objects, enumerating a list of the
+                statuses of ongoing and recently completed <a>Action</a> instances for that <a>Action</a>.
+              </td>
+            </tr>
+            <tr>
+              <td><code>timestamp</code></td>
+              <td>string</td>
+              <td>Optional</td>
+              <td>A timestamp in date-time format [[RFC3339]] set to the time the action statuses were reported.</td>
+            </tr>
+          </tbody>
+        </table>
+        <p>Each array in the <code>statuses</code> object MUST be sorted in reverse chronological order by
+          the time action instances were requested, such that the most recently requested action instance appears
+          first.</p>
+        <pre class="example" title="queryallactions response message">
+        {
+          "thingID": "https://mythingserver.com/things/mylamp1",
+          "messageID": "65cc48cd-7bf9-4e08-8b5a-91443704b0c7",
+          "messageType": "response",
+          "operation": "queryallactions",
+          "statuses": {
+            "fade": [
+              {
+                "actionID": "d95100b9-decc-4b11-81b8-81870597ebeb",
+                "timeRequested": "2025-09-09T17:38:13.631Z",
+                "status": "pending"
+              },
+              {
+                "actionID": "66546f79-84bd-4ac9-b728-bb4168a17330",
+                "timeRequested": "2025-09-09T17:36:00.363Z",
+                "status": "running"
+              },
+              {
+                "actionID": "c1e116a4-7832-4338-a72c-330c871b991a",
+                "status": "completed",
+                "timeRequested": "2025-09-09T17:34:50.361Z",
+                "timeEnded": "2025-09-09T17:34:55.361Z",
+                "output": true,
+              }
+            ],
+            "disco": []
+          },
+          "correlationID": "4c1c0ebc-775f-4b17-8f0f-e25c415f033d"
+        }
+        </pre>
+        <p class="note" title="Retention of ActionStatus objects">
+          When an Action instance is cancelled with a <code>cancelaction</code> operation, its ActionStatus object is
+          deleted and need not be retained. For all other <a>Action</a> instances it is assumed that once an action is
+          completed the Thing will store its ActionStatus object so that its status
+          may later be queried with a <code>queryaction</code> or <code>queryallactions</code> operation. It is not
+          expected that ActionStatus objects should be retained indefinitely, they may be stored in volatile memory
+          and/or periodically pruned. The length of time for which to retain ActionStatus objects is expected to be
+          implementation-specific and may depend on application-specific requirements or resource constraints. It is
+          recommended that at least the last instance of a completed action status should be stored.
+        </p>
+      </section>
+    </section>
+
     <section id="action-status-object">
       <h3>ActionStatus object</h3>
       <p>An ActionStatus object is used to represent the status of an <a>Action</a> instance in
@@ -2665,14 +2811,6 @@
           </tr>
         </tbody>
       </table>
-      <p class="note" title="Retention of ActionStatus objects">
-        It is assumed that once an action is completed the Thing will store its ActionStatus object so that its status
-        may later be queried with a <code>queryaction</code> or <code>queryallactions</code> operation. It is not
-        expected that ActionStatus objects should be retained indefinitely, they may be stored in volatile memory and/or
-        periodically pruned. The length of time for which to retain ActionStatus objects is expected to be
-        implementation-specific and may depend on application-specific requirements or resource constraints. It is
-        recommended that at least the last instance of a completed action status should be stored.
-      </p>
     </section>
 
     <section id="error-response">

--- a/index.html
+++ b/index.html
@@ -396,6 +396,11 @@
           <td><a href="#invokeaction-request">request</a>, <a href="#invokeaction-response">response</a>
           </td>
         </tr>
+        <tr>
+          <td><a href="#queryaction"><code>queryaction</code></a></td>
+          <td><a href="#queryaction-request">request</a>, <a href="#queryaction-response">response</a>
+          </td>
+        </tr>
       </tbody>
     </table>
 
@@ -2179,48 +2184,15 @@
                 <td>object</td>
                 <td>Mandatory</td>
                 <td>An <a href="#action-status-object"><code>ActionStatus</code></a> object representing the current
-                  status of the ongoing action.</td>
+                  status of the ongoing action, with its <code>state</code> member set to <code>pending</code> or
+                  <code>running</code>.
+                </td>
               </tr>
               <tr>
                 <td><code>timestamp</code></td>
                 <td>string</td>
                 <td>Optional</td>
                 <td>A timestamp in date-time format [[RFC3339]] set to the time the action request was accepted.</td>
-              </tr>
-            </tbody>
-          </table>
-          <table id="action-status-object" class="def">
-            <caption>Members of an <code>ActionStatus</code> object</caption>
-            <thead>
-              <tr>
-                <th>Member</th>
-                <th>Type</th>
-                <th>Assignment</th>
-                <th>Description</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td><code>actionID</code></td>
-                <td>string</td>
-                <td>Mandatory</td>
-                <td>A unique identifier in UUIDv4 format [[rfc9562]] which identifies the individual action instance,
-                  for use when querying or cancelling it.</td>
-              </tr>
-              <tr>
-                <td><code>state</code></td>
-                <td>string </td>
-                <td>Mandatory</td>
-                <td>A string representing the current state of the ongoing action. Set to either <code>pending</code> or
-                  <code>running</code>.
-                </td>
-              </tr>
-              <tr>
-                <td><code>timeRequested</code></td>
-                <td>string</td>
-                <td>Optional</td>
-                <td>A timestamp in date-time format [[RFC3339]] set to the time at which the Thing received the request
-                  to execute the Action.</td>
               </tr>
             </tbody>
           </table>
@@ -2271,6 +2243,314 @@
           then the error should be reported via a <code>queryaction</code> operation instead.
         </p>
       </section>
+    </section>
+
+    <section id="queryaction">
+      <h3><code>queryaction</code></h3>
+      <section id="queryaction-request">
+        <h4>Request</h4>
+        <p>To query the status of an ongoing asynchronous <a>Action</a>, a <a>Consumer</a> MUST send a
+          <a href="#websocket-messages">message</a> to the <a>Thing</a> which contains the following members:
+        </p>
+        <table class="def">
+          <caption>Members of an <code>queryaction</code> request message</caption>
+          <thead>
+            <tr>
+              <th>Member</th>
+              <th>Type</th>
+              <th>Assignment</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>messageType</code></td>
+              <td>string</td>
+              <td>"request"</td>
+              <td>A string which denotes that this message is a request sent from a Consumer to a Thing.</td>
+            </tr>
+            <tr>
+              <td><code>operation</code></td>
+              <td>string</td>
+              <td>"queryaction"</td>
+              <td>A string which denotes that this message relates to an <code>queryaction</code> operation.</td>
+            </tr>
+            <tr>
+              <td><code>actionID</code></td>
+              <td>string</td>
+              <td>Mandatory</td>
+              <td>A unique identifier in UUIDv4 format [[rfc9562]] which identifies the individual action instance being
+                queried, as provided in the corresponding <code>invokeaction</code> response.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <pre class="example" title="queryaction request message">
+        {
+          "thingID": "https://mythingserver.com/things/mylamp1",
+          "messageID": "f9dc3a42-188e-47f3-a0ed-cd3c3fb93207",
+          "messageType": "request",
+          "operation": "queryaction",
+          "actionID": "d95100b9-decc-4b11-81b8-81870597ebeb",
+          "correlationID": "f6293376-5ddb-43ef-ba21-aa34ceb48a58"
+        }
+        </pre>
+        <p>When a <a>Thing</a> receives a message from a <a>Consumer</a> with <code>messageType</code> set to
+          <code>request</code> and <code>operation</code> set to <code>queryaction</code> it MUST
+          attempt to query the status of the <a>Action</a> instance with the <code>actionID</code> provided in the
+          message.
+        </p>
+      </section>
+      <section id="queryaction-response">
+        <h4>Response</h4>
+        <p>Upon successfully querying the status of an asynchronous <a>Action</a> instance, the <a>Thing</a> MUST send a
+          message to the requesting <a>Consumer</a> containing the following members:
+
+        <table class="def">
+          <caption>Members of an <code>queryaction</code> response message</caption>
+          <thead>
+            <tr>
+              <th>Member</th>
+              <th>Type</th>
+              <th>Assignment</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>messageType</code></td>
+              <td>string</td>
+              <td>"response"</td>
+              <td>A string which denotes that this message is a response sent from a <a>Thing</a> to a
+                <a>Consumer</a>.
+              </td>
+            </tr>
+            <tr>
+              <td><code>operation</code></td>
+              <td>string</td>
+              <td>"queryaction"</td>
+              <td>A string which denotes that this message relates to a <code>queryaction</code> operation.
+              </td>
+            </tr>
+            <tr>
+              <td><code>name</code></td>
+              <td>string</td>
+              <td>Mandatory</td>
+              <td>The name of the <a>Action</a> that was queried, as per its key in the <code>actions</code> member of
+                the <a>Thing Description</a>.
+              </td>
+            </tr>
+            <tr>
+              <td><code>status</code></td>
+              <td>object</td>
+              <td>Mandatory</td>
+              <td>An <a href="#action-status-object"><code>ActionStatus</code></a> object representing the current
+                status of the <a>Action</a> instance.</td>
+            </tr>
+            <tr>
+              <td><code>timestamp</code></td>
+              <td>string</td>
+              <td>Optional</td>
+              <td>A timestamp in date-time format [[RFC3339]] set to the time the action status was reported.</td>
+            </tr>
+          </tbody>
+        </table>
+        <p>If the queried <a>Action</a> instance is currently pending (the action request has been accepted but
+          execution
+          has not yet started) then the <a>Thing</a> MUST respond with <code>state</code> set to <code>pending</code>.
+        </p>
+        <pre class="example" title="queryaction response message (pending)">
+        {
+          "thingID": "https://mythingserver.com/things/mylamp1",
+          "messageID": "84df00ce-dbe0-41fa-acf5-cdadcefd414e",
+          "messageType": "response",
+          "operation": "queryaction",
+          "name": "fade",
+          "status": {
+            "actionID": "d95100b9-decc-4b11-81b8-81870597ebeb",
+            "state": "pending",
+            "timeRequested": "2025-09-09T17:34:50.361Z",
+          },
+          "timestamp": "2025-09-09T17:34:51.531Z",
+          "correlationID": "f6293376-5ddb-43ef-ba21-aa34ceb48a58"
+        }
+        </pre>
+        <p>If the queried <a>Action</a> instance is currently running (execution has started but not finished) then the
+          <a>Thing</a> MUST respond with <code>state</code> set to <code>running</code>.
+        </p>
+        <pre class="example" title="queryaction response message (running)">
+        {
+          "thingID": "https://mythingserver.com/things/mylamp1",
+          "messageID": "b35e2161-2e66-4d91-9f4f-43cd05b36c32",
+          "messageType": "response",
+          "operation": "queryaction",
+          "name": "fade",
+          "status": {
+            "actionID": "d95100b9-decc-4b11-81b8-81870597ebeb",
+            "state": "running",
+            "timeRequested": "2025-09-09T17:34:50.361Z",
+          },
+          "timestamp": "2025-09-09T17:34:52.564Z",
+          "correlationID": "f6293376-5ddb-43ef-ba21-aa34ceb48a58"
+        }
+        </pre>
+        <p>If the queried <a>Action</a> instance has completed successfully (execution has finished and the output,
+          if any, is available) then the <a>Thing</a> MUST respond with <code>state</code> set to
+          <code>completed</code>,
+          and <code>output</code> set to the output of the <a>Action</a>, if any, with a type and structure conforming
+          to the data schema specified in the <code>output</code> member of the corresponding ActionAffordance in the
+          <a>Thing Description</a>.
+        </p>
+        <pre class="example" title="queryaction response message (completed)">
+        {
+          "thingID": "https://mythingserver.com/things/mylamp1",
+          "messageID": "a350c37e-b241-4848-9e3f-c6f21ce3f93c",
+          "messageType": "response",
+          "operation": "queryaction",
+          "name": "fade",
+          "status": {
+            "actionID": "d95100b9-decc-4b11-81b8-81870597ebeb",
+            "state": "completed",
+            "timeRequested": "2025-09-09T17:34:50.361Z",
+            "timeEnded": "2025-09-09T17:34:57.642Z",
+            "output": true,
+          },
+          "timestamp": "2025-09-09T17:34:58.564Z",
+          "correlationID": "f6293376-5ddb-43ef-ba21-aa34ceb48a58"
+        }
+        </pre>
+        <p>If the queried <a>Action</a> instance failed to execute then the <a>Thing</a> MUST respond with a
+          <code>status</code> containing an <code>error</code> member with its value set to an object conforming to the
+          Problem Details Format [[RFC9457]], including an error code appropriate for the type of error encountered.
+        </p>
+        <pre class="example" title="queryaction response message (failed)">
+        {
+          "thingID": "https://mythingserver.com/things/mylamp1",
+          "messageID": "120d4e13-01b3-450d-9223-fd2a8abcc20f",
+          "messageType": "response",
+          "operation": "queryaction",
+          "name": "fade",
+          "status": {
+            "state": "failed",
+            "timeRequested": "2025-09-09T17:34:50.361Z",
+            "timeEnded": "2025-09-09T17:34:51.531Z",
+            "error": {
+              "actionID": "d95100b9-decc-4b11-81b8-81870597ebeb",
+              "status": 500,
+              "type": "https://w3c.github.io/web-thing-protocol/errors#500",
+              "title": "Internal Server Error",
+              "detail": "The Thing was unable to complete the requested 'fade' action"
+            }
+          },
+          "timestamp": "2025-09-09T17:34:58.564Z",
+          "correlationID": "f6293376-5ddb-43ef-ba21-aa34ceb48a58"
+        }
+        </pre>
+        <p>A <a>Thing</a> MUST only send one response message for each <code>queryaction</code> request.</p>
+      </section>
+      <section id="queryaction-error-response">
+        <h4>Error Response</h4>
+        <p>If the <a>Thing</a> fails to query the status of the specified <a>Action</a> instance (e.g. because no
+          <a>Action</a> with the provided <code>actionID</code> exists), then the <a>Thing</a> MUST send an
+          <a href="#error-response">error response</a> to the <a>Consumer</a> with an error code appropriate for the
+          type of error encountered.
+        </p>
+        <pre class="example" title="queryaction error response">
+          {
+            "thingID": "https://mythingserver.com/things/mylamp1",
+            "messageID": "00d8803c-9eed-4097-b6a7-6ba83c7197f4",
+            "messageType": "response",
+            "operation": "queryaction",
+            "error": {
+              "status": 404,
+              "type": "https://w3c.github.io/web-thing-protocol/errors#404",
+              "title": "Not Found"
+              "detail": "No action instance with the specified actionID could be found"
+            }
+            "timestamp": "2025-09-09T17:34:58.564Z",
+            "correlationID": "f6293376-5ddb-43ef-ba21-aa34ceb48a58"
+          }
+        </pre>
+        <p class="note" title="Query error vs. action execution error">
+          If the Thing experiences an error querying an Action then the <code>error</code> member is included at the top
+          level of the <code>queryaction</code> response message. If the Thing experiences an error executing
+          the Action then the error member is included in the <code>status</code> member of the response message.
+          This helps to differentiate between an error querying the Action status vs. an error executing the Action.
+        </p>
+      </section>
+    </section>
+
+    <section id="action-status-object">
+      <h3>ActionStatus object</h3>
+      <p>An ActionStatus object is used to represent the status of an <a>Action</a> instance in
+        <code>invokeaction</code>, <code>queryaction</code> and <code>queryallactions</code> operations
+        and contains the following members:
+      </p>
+      <table class="def">
+        <caption>Members of an <code>ActionStatus</code> object</caption>
+        <thead>
+          <tr>
+            <th>Member</th>
+            <th>Type</th>
+            <th>Assignment</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>actionID</code></td>
+            <td>string</td>
+            <td>Mandatory</td>
+            <td>A unique identifier in UUIDv4 format [[rfc9562]] which identifies the individual action instance,
+              for use when querying or cancelling it.</td>
+          </tr>
+          <tr>
+            <td><code>state</code></td>
+            <td>string </td>
+            <td>Mandatory</td>
+            <td>A string representing the current state of the action. Set to either <code>pending</code>,
+              <code>running</code>, <code>completed</code> or <code>failed</code>.
+            </td>
+          </tr>
+          <tr>
+            <td><code>output</code></td>
+            <td>object</td>
+            <td>Optional</td>
+            <td>The output (if any) of the <a>Action</a> invoked, with a type and structure conforming to the data
+              schema specified in the <code>output</code> member of the corresponding ActionAffordance in the
+              <a>Thing Description</a>.
+            </td>
+          </tr>
+          <tr>
+            <td><code>error</code></td>
+            <td>object</td>
+            <td>Optional</td>
+            <td>An object conforming to the Problem Details Format [[RFC3339]].</td>
+          </tr>
+          <tr>
+            <td><code>timeRequested</code></td>
+            <td>string</td>
+            <td>Optional</td>
+            <td>A timestamp in date-time format [[RFC3339]] set to the time at which the <a>Thing</a> received the
+              request to execute the <a>Action</a>.</td>
+          </tr>
+          <tr>
+            <td><code>timeEnded</code></td>
+            <td>string</td>
+            <td>Optional</td>
+            <td>A timestamp in date-time format [[RFC3339]] set to the time at which the <a>Thing</a> successfully
+              completed executing the <a>Action</a>, or faield to execute the <a>Action</a>.</td>
+          </tr>
+        </tbody>
+      </table>
+      <p class="note" title="Retention of ActionStatus objects">
+        It is assumed that once an action is completed the Thing will store its ActionStatus object so that its status
+        may later be queried with a <code>queryaction</code> or <code>queryallactions</code> operation. It is not
+        expected that ActionStatus objects should be retained indefinitely, they may be stored in volatile memory and/or
+        periodically pruned. The length of time for which to retain ActionStatus objects is expected to be
+        implementation-specific and may depend on application-specific requirements or resource constraints. It is
+        recommended that at least the last instance of a completed action status should be stored.
+      </p>
     </section>
 
     <section id="error-response">


### PR DESCRIPTION
Closes #62.

This PR defines request and response message formats for a `queryallactions` operation, as discussed in https://github.com/w3c/web-thing-protocol/issues/43#issuecomment-3271505138

This PR currently builds on top of #91 and #93, so will need to be rebased once they have landed.

Open questions:
- I think the Thing Description specification is a bit ambiguous as to whether a `queryallactions` response is expected to show the status of _synchronous_ actions which may happen to be ongoing when the request is sent. My thinking is probably not, since the TD spec implies querying synchronous actions is not needed and my assumption would be that in the context of the Web Thing Protocol they wouldn't be assigned an `actionID`. This could be particularly relevant if a Thing has a mixture of synchronous and asynchronous Actions, although that would seem like a rare edge case. We may want to add a note to clarify this point either way.