### PR TITLE
Split WebSocket Messages section into subsections for readability - closes #100

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
-  <meta charset="utf-8" />
+  <meta charset="utf-8">
   <title>Web Thing Protocol</title>
   <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
   <script class="remove">
@@ -150,6 +150,7 @@
           Description</a>
         [[wot-architecture11]] by locating a <a href="https://www.w3.org/TR/wot-thing-description/#form">Form</a> inside
         the corresponding <a>Interaction Affordance</a> for which:
+      </p>
       <ul>
         <li>After being resolved against a <a
             href="https://www.w3.org/TR/wot-thing-description/#td-vocab-base--Thing"><code>base</code></a> URL
@@ -160,7 +161,6 @@
             href="https://www.w3.org/TR/wot-thing-description/#td-vocab-subprotocol--Form"><code>subprotocol</code></a>
           member has a value of <code>"webthingprotocol"</code></li>
       </ul>
-      </p>
       <p>To open a WebSocket on a Thing, an HTTP <a
           href="https://httpwg.org/specs/rfc9110.html#GET"><code>GET</code></a> request [[RFC9110]] MUST be upgraded to
         a WebSocket connection using a standard WebSocket <a
@@ -309,7 +309,7 @@
               action or subscribe to an event)</td>
           </tr>
           <tr>
-            <td><code>response</code></a></td>
+            <td><code>response</code></td>
             <td>Thing ➡ Consumer</td>
             <td>A message sent from a Thing to a Consumer in response to a request (e.g. to respond with a property
               reading, provide the final response to an action or confirm a subscription to an event)</td>
@@ -332,7 +332,7 @@
         same operation MUST also include a <code>correlationID</code> member with the same value.</p>
 
       <p>All date and time values MUST use the <code>date-time</code> format
-        defined in [[RFC3339]].</span>
+        defined in [[RFC3339]].
       </p>
       <pre class="example" title="Example timestamp">
         <code>2025-01-15T12:08:00.42Z</code>
@@ -744,7 +744,6 @@
             <a>Property</a>'s data schema but to a level of precision the Thing does not support, (e.g. 3.14159), then
             the
             <a>Thing</a> MAY respond with the actual value set (e.g. 3.14).
-          </p>
           </p>
         </section>
       </section>


### PR DESCRIPTION
Closes #100.

This PR splits the WebSocket Messages section into more subsections to improve readability:

5. WebSocket Messages
  5.1 Message Format
  5.2 Operation Lifecycles
  5.3 Property Operations
  5.4 Action Operations
  5.5 Event Operations
  5.6 Error Response

I've also done a little bit of HTML cleanup.

This looks like a huge diff but it's mainly just adding additional subsections and changing heading levels.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/benfrancis/web-thing-protocol/pull/106.html" title="Last updated on Oct 16, 2025, 11:59 AM UTC (dbdf2e5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-thing-protocol/106/d0bc6d2...benfrancis:dbdf2e5.html" title="Last updated on Oct 16, 2025, 11:59 AM UTC (dbdf2e5)">Diff</a>