### PR TITLE
Remove note about empty sections and text about other messages

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,13 +45,7 @@
   </section>
 
   <section id="sotd">
-    <aside class="ed-note" title="Empty Sections">
-      Please note that this document is a work in progress and contains empty
-      sections. For an indication of what these sections may eventually contain,
-      please see this
-      <a href="https://docs.google.com/document/d/1KWv-aQfMgsqBFg0v4rVqzcVvzzisC7y4X4CMUYGc8rE/edit?usp=sharing">strawman
-        proposal</a>.
-    </aside>
+
   </section>
 
   <section id="introduction" class="informative">
@@ -101,8 +95,7 @@
       <a href="https://www.w3.org/TR/wot-thing-description11/#table-well-known-operation-types">
         operation types</a> defined in the WoT
       <a href="https://www.w3.org/TR/wot-architecture/#sec-interaction-model">
-        interaction model</a> [[wot-architecture11]], and other messages needed for
-      WebSocket communication.
+        interaction model</a> [[wot-architecture11]].
     </p>
     <p>
       This specification is intended to complement deliverables of the


### PR DESCRIPTION
This small editorial PR just removes an old note about there being lots of empty sections, which had a link to the now outdated strawman proposal.

I also removed a mention in the introduction of "other messages needed for WebSocket communication" which was meant to refer to ping and pong messages that haven't been added so far.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/benfrancis/web-thing-protocol/pull/113.html" title="Last updated on Oct 24, 2025, 11:13 AM UTC (35610e2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-thing-protocol/113/d0bc6d2...benfrancis:35610e2.html" title="Last updated on Oct 24, 2025, 11:13 AM UTC (35610e2)">Diff</a>